### PR TITLE
806 added second hook

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ class LaunchPublish(Application):
     def init_app(self):
         deny_permissions = self.get_setting("deny_permissions")
         deny_platforms = self.get_setting("deny_platforms")
-        title = self.get_setting("display_name")
+        title = self.get_setting("display_name", "Open in Associated Application")
         
         p = {
             "title": title,

--- a/app.py
+++ b/app.py
@@ -35,9 +35,10 @@ class LaunchPublish(Application):
     def init_app(self):
         deny_permissions = self.get_setting("deny_permissions")
         deny_platforms = self.get_setting("deny_platforms")
+        title = self.get_setting("display_name")
         
         p = {
-            "title": "Open in Associated Application",
+            "title": title,
             "deny_permissions": deny_permissions,
             "deny_platforms": deny_platforms,
             "supports_multiple_selection": False
@@ -66,7 +67,6 @@ class LaunchPublish(Application):
         if exit_code != 0:
             self.log_error("Failed to launch '%s'!" % cmd)
 
-
     def _launch_viewer(self, path):
         """
         Launches an image viewer based on config settings.
@@ -90,7 +90,7 @@ class LaunchPublish(Application):
         if system.startswith("linux"):
             cmd = '%s "%s" &' % (app_path, path)
         elif system == "darwin":
-            cmd = 'open -n "%s" --args "%s"' % (app_path, path)
+            cmd = 'open -a "%s" "%s"' % (app_path, path)
         elif system == "win32":
             cmd = 'start /B "Maya" "%s" "%s"' % (app_path, path)
         else:
@@ -107,7 +107,6 @@ class LaunchPublish(Application):
                           "on support@shotgunsoftware.com." % app_path )
 
     def launch_publish(self, entity_type, entity_ids):
-        
         published_file_entity_type = tank.util.get_published_file_entity_type(self.tank)
         
         if entity_type not in [published_file_entity_type, "Version"]:

--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ class LaunchPublish(Application):
         if system.startswith("linux"):
             cmd = '%s "%s" &' % (app_path, path)
         elif system == "darwin":
-            cmd = 'open -a "%s" "%s"' % (app_path, path)
+            cmd = 'open -n -a "%s" "%s"' % (app_path, path)
         elif system == "win32":
             cmd = 'start /B "Maya" "%s" "%s"' % (app_path, path)
         else:

--- a/hooks/shotgun_get_published_file.py
+++ b/hooks/shotgun_get_published_file.py
@@ -23,7 +23,7 @@ from sgtk import TankError
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
-class GetPublishedFileForViewer(HookBaseClass):
+class GetPublishedFile(HookBaseClass):
     _PUBLISHED_FILE_FIELDS = ["path", "task", "entity"]
 
     def execute(self, entity_type, entity_id, published_file_entity_type, **kwargs):

--- a/hooks/shotgun_get_published_file.py
+++ b/hooks/shotgun_get_published_file.py
@@ -71,7 +71,7 @@ class GetPublishedFile(HookBaseClass):
                         "Sorry, viewer extensions must be provided when a Version has multiple PublishedFiles"
                     )
                 published_file_ids = [pf["id"] for pf in v[published_files_field]]
-                published_files = self.sgtk.shotgun.find(
+                published_files = self.parent.shotgun.find(
                     published_file_entity_type,
                     [["id", "in", published_file_ids]],
                     ["path", "task", "entity"]

--- a/hooks/shotgun_get_published_file.py
+++ b/hooks/shotgun_get_published_file.py
@@ -12,18 +12,10 @@
 Hook executed to get a PublishedFile from a Version
 or a PublishedFile (legacy TankPublishedFile supported).
 
-If it is a Version and there's more than one PublishedFile linked
-to it, this hook allows to determine which PublishedFile to pick.
+It decides which published file to return, or if it needs to raise a TankError.
 
-The default implementation cycles through the `viewer_extensions`
-config parameter, and returns the first published file matching
-one of the extensions.
+This default implementation returns the first published file it finds, with the proper fields.
 
-This allows to select PublishedFiles based on the order of
-`viewer_extensions`.
-
-If none of the PublishedFiles match any of the extensions,
-return the first one in the list.
 """
 import sgtk
 from sgtk import TankError
@@ -31,7 +23,9 @@ from sgtk import TankError
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
-class GetPublishedFile(HookBaseClass):
+class GetPublishedFileForViewer(HookBaseClass):
+    _PUBLISHED_FILE_FIELDS = ["path", "task", "entity"]
+
     def execute(self, entity_type, entity_id, published_file_entity_type, **kwargs):
         """
         Given a Version, PublishedFile or TankPublishedFile,
@@ -61,40 +55,48 @@ class GetPublishedFile(HookBaseClass):
             if not v.get(published_files_field):
                 raise TankError("Sorry, this can only be used on Versions with an associated published file.")
             if len(v[published_files_field]) == 1:
-                publish_id = v[published_files_field][0]["id"]
-                return self.published_file(published_file_entity_type, publish_id)
-            else:
-                # if there are multiple published files, pick one.
-                viewer_extensions = self.parent.get_setting("viewer_extensions")
-                if not viewer_extensions:
-                    raise TankError(
-                        "Sorry, viewer extensions must be provided when a Version has multiple PublishedFiles"
-                    )
-                published_file_ids = [pf["id"] for pf in v[published_files_field]]
-                published_files = self.parent.shotgun.find(
+                return self.resolve_single_file(
                     published_file_entity_type,
-                    [["id", "in", published_file_ids]],
-                    ["path", "task", "entity"]
+                    v[published_files_field][0],
                 )
-                for viewer_extension in viewer_extensions:
-                    for published_file in published_files:
-                        path_on_disk = self.parent.get_path_on_disk(published_file)
-                        if path_on_disk and path_on_disk.endswith(".%s" % viewer_extension):
-                            return published_file
-                return published_files[0]
+            else:
+                return self.resolve_multiple_files(
+                    published_file_entity_type,
+                    v[published_files_field]
+                )
         else:
             # entity is PublishedFile or TankPublishedFile. Return it
             return self.published_file(entity_type, entity_id)
 
-    def published_file(self, entity_type, entity_id):
+    def resolve_single_file(self, entity_type, published_file):
+        """
+        Decide wether or not to return the published file, or raise a TankError.
+        This default implementation returns it.
+
+        :param str entity_type: PublishedFile or TankPublishedFile.
+        :param dict published_file: The published file.
+        :returns: The published file with the right fields.
+        """
+        return self.published_file(entity_type, published_file["id"])
+
+    def resolve_multiple_files(self, published_file_type, published_files):
+        """
+        Decide which published file to return, or raise a TankError.
+        This default implementation returns the first one.
+        :param str published_file_type: PublishedFile or TankPublishedFile.
+        :param list published_files: The published files.
+        :returns: The first published file with the right fields.
+        """
+        return self.published_file(published_file_type, published_files[0]["id"])
+
+    def published_file(self, published_file_type, published_file_id):
         """
         Return the PublishedFile or TankPublishedFile with path, task and entity
-        fields
-
-        :param entity_type: PublishedFile or TankPublishedFile
-        :param entity_id: a Shotgun ID.
+        fields.
+        :param str published_file_type: PublishedFile or TankPublishedFile
+        :param int published_file_id: a Shotgun ID.
         :returns: the published file with the right fields.
         """
         return self.parent.shotgun.find_one(
-            entity_type,
-            [["id", "is", entity_id]], ["path", "task", "entity"])
+            published_file_type,
+            [["id", "is", published_file_id]], self._PUBLISHED_FILE_FIELDS)

--- a/hooks/shotgun_get_published_file_for_viewer.py
+++ b/hooks/shotgun_get_published_file_for_viewer.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook executed to get a PublishedFile from a Version
+or a PublishedFile (legacy TankPublishedFile supported).
+
+This implementation returns the first published file it finds
+matching extensions in the order of viewer extensions.
+If none are found, raise a TankError.
+"""
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class GetPublishedFileForViewer(HookBaseClass):
+    """
+    In order to work, this hook needs to inherit from shotgun_get_published_file.GetPublishedFile
+    """
+
+    def resolve_single_file(self, entity_type, published_file):
+        """
+        Decide wether or not to return the published file, or raise a TankError.
+        This default implementation returns the published file only if it matches
+        one of the viewer_extensions.
+
+        :param str entity_type: PublishedFile or TankPublishedFile.
+        :param dict published_file: The published file.
+        :returns: The published file with the right fields.
+        :raises: TankError
+        """
+        viewer_extensions = self.parent.get_setting("viewer_extensions")
+        if not viewer_extensions:
+            raise TankError(
+                "Sorry, viewer extensions must be provided."
+            )
+        path_on_disk = self.parent.get_path_on_disk(published_file)
+        if path_on_disk:
+            for viewer_extension in viewer_extensions:
+                if path_on_disk.endswith(".%s" % viewer_extension):
+                    return self.published_file(entity_type, published_file["id"])
+        raise TankError("Published File %s does not match viewer extensions %s" % (
+            published_file,
+            viewer_extensions
+        ))
+
+    def resolve_multiple_files(self, published_file_type, published_files):
+        """
+        Decide which published file to return, or raise a TankError.
+        Return the first published file matching a viewer extension,
+        otherwise raise a TankError.
+
+        :param str published_file_type: PublishedFile or TankPublishedFile.
+        :param list published_files: The published files.
+        :returns: The first published file with the right fields.
+        :raises: TankError
+        """
+        viewer_extensions = self.parent.get_setting("viewer_extensions")
+        if not viewer_extensions:
+            raise TankError(
+                "Sorry, viewer extensions must be provided."
+            )
+        published_file_ids = [pf["id"] for pf in published_files]
+        published_files = self.sgtk.shotgun.find(
+            published_file_type,
+            [["id", "in", published_file_ids]],
+            self._PUBLISHED_FILE_FIELDS
+        )
+        for viewer_extension in viewer_extensions:
+            for published_file in published_files:
+                path_on_disk = self.parent.get_path_on_disk(published_file)
+                if path_on_disk and path_on_disk.endswith(".%s" % viewer_extension):
+                    return published_file
+        raise TankError(
+            "Could not find a published file matching viewer extensions %s. Published files: %s" % (
+                viewer_extensions,
+                published_files
+            )
+        )
+


### PR DESCRIPTION
* the first default hook just returns the first file it finds
* the second default hook inherits from the first one, but returns a published file only if it matches one of the viewer extensions, in order. If not, it raises a TankError